### PR TITLE
wasi: improve JavaScript API

### DIFF
--- a/lib/wasi.js
+++ b/lib/wasi.js
@@ -1,6 +1,7 @@
 // TODO(cjihrig): Put WASI behind a flag.
 // TODO(cjihrig): Provide a mechanism to bind to WASM modules.
 'use strict';
+/* global WebAssembly */
 const { Array, ArrayPrototype } = primordials;
 const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
 const { WASI: _WASI } = internalBinding('wasi');
@@ -12,7 +13,7 @@ class WASI {
       throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
 
     // eslint-disable-next-line prefer-const
-    let { args, env, preopens } = options;
+    let { args, env, preopens, memory } = options;
 
     if (Array.isArray(args))
       args = ArrayPrototype.map(args, (arg) => { return String(arg); });
@@ -43,12 +44,37 @@ class WASI {
 
     // TODO(cjihrig): Validate preopen object schema.
 
-    // TODO(cjihrig): Temporarily expose these for development.
-    // eslint-disable-next-line no-undef
-    const memory = Buffer.alloc(200000);
-    this._memory = memory;
-    this._view = new DataView(memory.buffer);
-    this._wasi = new _WASI(args, envPairs, preopens, memory);
+    if (memory instanceof WebAssembly.Memory) {
+      memory = memory.buffer;
+    } else {
+      throw new ERR_INVALID_ARG_TYPE(
+        'options.memory', 'WebAssembly.Memory', memory);
+    }
+
+    const wrap = new _WASI(args, envPairs, preopens, memory);
+
+    for (const prop in wrap) {
+      wrap[prop] = wrap[prop].bind(wrap);
+    }
+
+    this.wasiImport = wrap;
+  }
+
+  static start(instance) {
+    if (!(instance instanceof WebAssembly.Instance)) {
+      throw new ERR_INVALID_ARG_TYPE(
+        'instance', 'WebAssembly.Instance', instance);
+    }
+
+    const exports = instance.exports;
+
+    if (exports === null || typeof exports !== 'object')
+      throw new ERR_INVALID_ARG_TYPE('instance.exports', 'Object', exports);
+
+    if (exports._start)
+      exports._start();
+    else if (exports.__wasi_unstable_reactor_start)
+      exports.__wasi_unstable_reactor_start();
   }
 }
 

--- a/lib/wasi.js
+++ b/lib/wasi.js
@@ -5,6 +5,7 @@
 const { Array, ArrayPrototype } = primordials;
 const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
 const { WASI: _WASI } = internalBinding('wasi');
+const { isAnyArrayBuffer } = require('internal/util/types');
 
 
 class WASI {
@@ -46,7 +47,7 @@ class WASI {
 
     if (memory instanceof WebAssembly.Memory) {
       memory = memory.buffer;
-    } else {
+    } else if (!isAnyArrayBuffer(memory)) {
       throw new ERR_INVALID_ARG_TYPE(
         'options.memory', 'WebAssembly.Memory', memory);
     }

--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -41,7 +41,7 @@ void WASI::New(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsArray());
   CHECK(args[1]->IsArray());
   // CHECK(args[2]->IsArray());
-  CHECK(args[3]->IsArrayBuffer());
+  CHECK(args[3]->IsArrayBuffer() || args[3]->IsSharedArrayBuffer());
 
   Environment* env = Environment::GetCurrent(args);
   Local<Context> context = env->context();

--- a/src/node_wasi.h
+++ b/src/node_wasi.h
@@ -77,7 +77,7 @@ class WASI : public BaseObject {
   ~WASI() override;
   inline uvwasi_errno_t writeUInt32(uint32_t value, uint32_t offset);
   uvwasi_t uvw_;
-  v8::Persistent<v8::ArrayBufferView> memory_;
+  v8::Persistent<v8::ArrayBuffer> memory_;
 };
 
 


### PR DESCRIPTION
- Add `WASI.start()`. This calls `_start()` or `__wasi_unstable_reactor_start()`, if present.
- Export a valid `wasi_unstable` import. This can be included as part of an imports object passed to `WebAssembly.instantiate()`, etc.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)