### PR TITLE
src: fix compiler warnings in node_wasi.cc

### DIFF
--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -80,8 +80,8 @@ void WASI::New(const FunctionCallbackInfo<Value>& args) {
   options.preopenc = 1;
   options.preopens =
     static_cast<uvwasi_preopen_t*>(calloc(1, sizeof(uvwasi_preopen_t)));
-  options.preopens[0].mapped_path = "/var";
-  options.preopens[0].real_path = ".";
+  options.preopens[0].mapped_path = const_cast<char*>("/var");
+  options.preopens[0].real_path = const_cast<char*>(".");
 
   new WASI(env, args.This(), args[3], &options);
 


### PR DESCRIPTION
Currently the following compiler warnings are generated:
```console
make: *** [node] Error 2
../src/node_wasi.cc:83:37:warning:
ISO C++11 does not allow conversion from string literal to 'char *'
[-Wwritable-strings]
  options.preopens[0].mapped_path = "/var";
                                    ^
../src/node_wasi.cc:84:35: warning:
ISO C++11 does not allow conversion from string literal to 'char *'
[-Wwritable-strings]
  options.preopens[0].real_path = ".";
                                  ^
2 warnings generated.
```
This commit adds a const_cast to these string literals.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
