### PR TITLE
wasi: add input handling macros

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -532,7 +532,8 @@ struct ContextInfo {
 #define DEBUG_CATEGORY_NAMES(V)                                                \
   NODE_ASYNC_PROVIDER_TYPES(V)                                                 \
   V(INSPECTOR_SERVER)                                                          \
-  V(INSPECTOR_PROFILER)
+  V(INSPECTOR_PROFILER)                                                        \
+  V(WASI)
 
 enum class DebugCategory {
 #define V(name) name,


### PR DESCRIPTION
This commit introduces three macros. Two of them are for validating input, instead of hard `CHECK`s, since these functions can technically be user-facing (although the intention is for
the WASM runtime to call them). The third macro is for debugging, as visibility into the WASI calls is somewhat limited. Once this is merged, the macros can be applied to all of the other calls.