### PR TITLE
wasi: adjust wasm memory interfacing

### DIFF
--- a/deps/uvwasi/src/uvwasi.c
+++ b/deps/uvwasi/src/uvwasi.c
@@ -767,7 +767,7 @@ uvwasi_errno_t uvwasi_fd_prestat_get(uvwasi_t* uvwasi,
     return UVWASI_EINVAL;
 
   buf->pr_type = UVWASI_PREOPENTYPE_DIR;
-  buf->u.dir.pr_name_len = strlen(wrap->path);
+  buf->u.dir.pr_name_len = strlen(wrap->path) + 1;
   return UVWASI_ESUCCESS;
 }
 

--- a/lib/wasi.js
+++ b/lib/wasi.js
@@ -5,7 +5,7 @@
 const { Array, ArrayPrototype } = primordials;
 const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
 const { WASI: _WASI } = internalBinding('wasi');
-const { isAnyArrayBuffer } = require('internal/util/types');
+const kSetMemory = Symbol('setMemory');
 
 
 class WASI {
@@ -14,7 +14,7 @@ class WASI {
       throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
 
     // eslint-disable-next-line prefer-const
-    let { args, env, preopens, memory } = options;
+    let { args, env, preopens } = options;
 
     if (Array.isArray(args))
       args = ArrayPrototype.map(args, (arg) => { return String(arg); });
@@ -45,23 +45,18 @@ class WASI {
 
     // TODO(cjihrig): Validate preopen object schema.
 
-    if (memory instanceof WebAssembly.Memory) {
-      memory = memory.buffer;
-    } else if (!isAnyArrayBuffer(memory)) {
-      throw new ERR_INVALID_ARG_TYPE(
-        'options.memory', 'WebAssembly.Memory', memory);
-    }
-
-    const wrap = new _WASI(args, envPairs, preopens, memory);
+    const wrap = new _WASI(args, envPairs, preopens);
 
     for (const prop in wrap) {
       wrap[prop] = wrap[prop].bind(wrap);
     }
 
+    this[kSetMemory] = wrap._setMemory;
+    delete wrap._setMemory;
     this.wasiImport = wrap;
   }
 
-  static start(instance) {
+  start(instance) {
     if (!(instance instanceof WebAssembly.Instance)) {
       throw new ERR_INVALID_ARG_TYPE(
         'instance', 'WebAssembly.Instance', instance);
@@ -71,6 +66,15 @@ class WASI {
 
     if (exports === null || typeof exports !== 'object')
       throw new ERR_INVALID_ARG_TYPE('instance.exports', 'Object', exports);
+
+    const { memory } = exports;
+
+    if (!(memory instanceof WebAssembly.Memory)) {
+      throw new ERR_INVALID_ARG_TYPE(
+        'instance.exports.memory', 'WebAssembly.Memory', memory);
+    }
+
+    this[kSetMemory](memory);
 
     if (exports._start)
       exports._start();

--- a/src/node_wasi.h
+++ b/src/node_wasi.h
@@ -14,7 +14,6 @@ class WASI : public BaseObject {
  public:
   WASI(Environment* env,
        v8::Local<v8::Object> object,
-       v8::Local<v8::Value> memory,
        uvwasi_options_t* options);
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   SET_NO_MEMORY_INFO()
@@ -73,11 +72,17 @@ class WASI : public BaseObject {
   static void SockSend(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SockShutdown(const v8::FunctionCallbackInfo<v8::Value>& args);
 
+  static void _SetMemory(const v8::FunctionCallbackInfo<v8::Value>& args);
+
  private:
   ~WASI() override;
+  inline uvwasi_errno_t writeUInt8(uint8_t value, uint32_t offset);
+  inline uvwasi_errno_t writeUInt16(uint16_t value, uint32_t offset);
   inline uvwasi_errno_t writeUInt32(uint32_t value, uint32_t offset);
+  inline uvwasi_errno_t writeUInt64(uint64_t value, uint32_t offset);
+  uvwasi_errno_t backingStore(char** store, size_t* byte_length);
   uvwasi_t uvw_;
-  v8::Persistent<v8::ArrayBuffer> memory_;
+  v8::Persistent<v8::Object> memory_;
 };
 
 


### PR DESCRIPTION
This PR implements a number of the system calls more completely, moves `WASI.start()` to `WASI.prototype.start()`, and adjusts the way the C++ layer interfaces with the WASM memory.