### PR TITLE
wasi: replace build.sh with make

### DIFF
--- a/test/wasi/Makefile
+++ b/test/wasi/Makefile
@@ -1,0 +1,12 @@
+CC = /opt/wasi-sdk/bin/clang
+TARGET = wasm32-unknown-wasi
+SYSROOT =
+
+OBJ = $(patsubst c/%.c, wasm/%.wasm, $(wildcard c/*.c))
+all: $(OBJ)
+
+wasm/%.wasm : c/%.c
+	$(CC) $< --target=$(TARGET) --sysroot=$(SYSROOT) -s -o $@
+
+.PHONY clean:
+	rm -f $(OBJ)

--- a/test/wasi/README.md
+++ b/test/wasi/README.md
@@ -1,5 +1,8 @@
 # WASI Tests
 
 Compile with clang and `wasm32-wasi` target. The clang version used must be
-built with wasi-libc. See `build.sh` in this directory for the exact
-commands used.
+built with wasi-libc. You can specify the location for clang and the sysroot
+if needed when running make:
+```console
+$ make CC=/usr/local/opt/llvm/bin/clang SYSROOT=/path/to/wasi-libc/sysroot
+```

--- a/test/wasi/build.sh
+++ b/test/wasi/build.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-for file in c/*.c; do
-  filename=$(basename -- "$file")
-  filename="${filename%.*}"
-  /opt/wasi-sdk/bin/clang $file -target wasm32-unknown-wasi -o wasm/$filename.wasm
-done


### PR DESCRIPTION
This commit suggests replacing the build script, which
compiles the c programs to wasm, to use make instead.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
