### PR TITLE
wasi: implement path_open()

### DIFF
--- a/deps/uvwasi/src/uvwasi.c
+++ b/deps/uvwasi/src/uvwasi.c
@@ -58,7 +58,7 @@ static uvwasi_errno_t uvwasi__resolve_path(const struct uvwasi_fd_wrap_t* fd,
     memcpy(abs_path, path, abs_size);
   } else {
     /* Resolve the relative path to fd's real path. */
-    abs_size = path_len + strlen(fd->real_path) + 1; /* +1 for the "/" */
+    abs_size = path_len + strlen(fd->real_path) + 2;
     abs_path = malloc(abs_size);
     if (abs_path == NULL) {
       err = UVWASI_ENOMEM;
@@ -66,7 +66,7 @@ static uvwasi_errno_t uvwasi__resolve_path(const struct uvwasi_fd_wrap_t* fd,
     }
 
     r = snprintf(abs_path, abs_size, "%s/%s", fd->real_path, path);
-    if (r != abs_size - 1) {
+    if (r <= 0) {
       err = uvwasi__translate_uv_error(uv_translate_sys_error(errno));
       goto exit;
     }

--- a/test/wasi/test-wasi.js
+++ b/test/wasi/test-wasi.js
@@ -8,22 +8,12 @@ if (process.argv[2] === 'wasi-child') {
   const wasmDir = path.join(__dirname, 'wasm');
   const memory = new WebAssembly.Memory({ initial: 3 });
   const wasi = new WASI({ args: [], env: process.env, memory });
-
-  // TODO(cjihrig): Patch the import object until the native bindings are ready.
-  let instance = null;
-
-  wasi.wasiImport.path_open = function() {
-    // Called by the 'cant_dotdot' test.
-    return 76; // ENOTCAPABLE
-  };
-  // End of import object patching.
-
   const importObject = { wasi_unstable: wasi.wasiImport };
   const modulePath = path.join(wasmDir, `${process.argv[3]}.wasm`);
   const buffer = fs.readFileSync(modulePath);
 
   (async () => {
-    ({ instance } = await WebAssembly.instantiate(buffer, importObject));
+    const { instance } = await WebAssembly.instantiate(buffer, importObject);
 
     wasi.start(instance);
   })();


### PR DESCRIPTION
This PR implements `__wasi_path_open()`. With this call being implemented, all of the current tests in `test/wasi/test-wasi.js` without any monkey patching of the WASI import 🍾 