### PR TITLE
wasi: just inlcude base_object.h in node_wasi.h

### DIFF
--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -1,4 +1,5 @@
 #include "env-inl.h"
+#include "base_object-inl.h"
 #include "debug_utils.h"
 #include "util-inl.h"
 #include "node.h"

--- a/src/node_wasi.h
+++ b/src/node_wasi.h
@@ -3,7 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "base_object-inl.h"
+#include "base_object.h"
 #include "uvwasi.h"
 
 namespace node {


### PR DESCRIPTION
This commit replaces the inclusion of base_object-inl.h in node_wasi.h
with base_object.h and instead lets node_wasi.cc include the inline
header.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
