### PR TITLE
wasi: bounds check all memory operations

### DIFF
--- a/lib/wasi.js
+++ b/lib/wasi.js
@@ -1,5 +1,4 @@
 // TODO(cjihrig): Put WASI behind a flag.
-// TODO(cjihrig): Provide a mechanism to bind to WASM modules.
 'use strict';
 /* global WebAssembly */
 const { Array, ArrayPrototype, Object } = primordials;

--- a/src/node_wasi.h
+++ b/src/node_wasi.h
@@ -76,11 +76,11 @@ class WASI : public BaseObject {
 
  private:
   ~WASI() override;
-  inline uvwasi_errno_t readUInt32(uint32_t* value, uint32_t offset);
-  inline uvwasi_errno_t writeUInt8(uint8_t value, uint32_t offset);
-  inline uvwasi_errno_t writeUInt16(uint16_t value, uint32_t offset);
-  inline uvwasi_errno_t writeUInt32(uint32_t value, uint32_t offset);
-  inline uvwasi_errno_t writeUInt64(uint64_t value, uint32_t offset);
+  inline void readUInt32(char* memory, uint32_t* value, uint32_t offset);
+  inline void writeUInt8(char* memory, uint8_t value, uint32_t offset);
+  inline void writeUInt16(char* memory, uint16_t value, uint32_t offset);
+  inline void writeUInt32(char* memory, uint32_t value, uint32_t offset);
+  inline void writeUInt64(char* memory, uint64_t value, uint32_t offset);
   uvwasi_errno_t backingStore(char** store, size_t* byte_length);
   uvwasi_t uvw_;
   v8::Persistent<v8::Object> memory_;


### PR DESCRIPTION
All of the memory accesses are now bounds checked. The only remaining unchecked operation is `poll_oneoff()`, which is not yet implemented.