### PR TITLE
wasi: update uvwasi

### DIFF
--- a/deps/uvwasi/include/uvwasi.h
+++ b/deps/uvwasi/include/uvwasi.h
@@ -37,6 +37,7 @@ typedef struct uvwasi_options_s {
 
 
 uvwasi_errno_t uvwasi_init(uvwasi_t* uvwasi, uvwasi_options_t* options);
+void uvwasi_destroy(uvwasi_t* uvwasi);
 
 uvwasi_errno_t uvwasi_args_get(uvwasi_t* uvwasi, char** argv, char* argv_buf);
 uvwasi_errno_t uvwasi_args_sizes_get(uvwasi_t* uvwasi,

--- a/deps/uvwasi/src/fd_table.c
+++ b/deps/uvwasi/src/fd_table.c
@@ -282,8 +282,7 @@ uvwasi_errno_t uvwasi_fd_table_init(struct uvwasi_fd_table_t* table,
 
   return UVWASI_ESUCCESS;
 error_exit:
-  free(table->fds);
-  table->fds = NULL;
+  uvwasi_fd_table_free(table);
   return err;
 }
 

--- a/deps/uvwasi/src/uvwasi.c
+++ b/deps/uvwasi/src/uvwasi.c
@@ -305,6 +305,15 @@ uvwasi_errno_t uvwasi_init(uvwasi_t* uvwasi, uvwasi_options_t* options) {
   return UVWASI_ESUCCESS;
 
 exit:
+  uvwasi_destroy(uvwasi);
+  return err;
+}
+
+
+void uvwasi_destroy(uvwasi_t* uvwasi) {
+  if (uvwasi == NULL)
+    return;
+
   uvwasi_fd_table_free(&uvwasi->fds);
   free(uvwasi->argv_buf);
   free(uvwasi->argv);
@@ -314,7 +323,6 @@ exit:
   uvwasi->argv = NULL;
   uvwasi->env_buf = NULL;
   uvwasi->env = NULL;
-  return err;
 }
 
 

--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -74,6 +74,7 @@ WASI::WASI(Environment* env,
 
 WASI::~WASI() {
   /* TODO(cjihrig): Free memory. */
+  uvwasi_destroy(&uvw_);
 }
 
 


### PR DESCRIPTION
This PR syncs with the latest uvwasi. It also uses the new `uvwasi_destroy()` in the WASI C++ destructor.