### PR TITLE
wasi: put wasi behind a flag

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -191,6 +191,13 @@ added: v9.6.0
 
 Enable experimental ES Module support in the `vm` module.
 
+### `--experimental-wasi`
+<!-- YAML
+added: REPLACEME
+-->
+
+Enable experimental WebAssembly System Interface (WASI) support.
+
 ### `--experimental-wasm-modules`
 <!-- YAML
 added: v12.3.0
@@ -986,6 +993,7 @@ Node.js options that are allowed are:
 * `--experimental-repl-await`
 * `--experimental-report`
 * `--experimental-vm-modules`
+* `--experimental-wasi`
 * `--experimental-wasm-modules`
 * `--force-context-aware`
 * `--force-fips`

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -155,6 +155,9 @@ function NativeModule(id) {
   this.loaded = false;
   this.loading = false;
   this.canBeRequiredByUsers = !id.startsWith('internal/');
+
+  if (id === 'wasi')
+    this.canBeRequiredByUsers = !!internalBinding('config').experimentalWasi;
 }
 
 // To be called during pre-execution when --expose-internals is on.

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -119,6 +119,11 @@ const builtinLibs = [
   'v8', 'vm', 'worker_threads', 'zlib'
 ];
 
+if (internalBinding('config').experimentalWasi) {
+  builtinLibs.push('wasi');
+  builtinLibs.sort();
+}
+
 if (typeof internalBinding('inspector').open === 'function') {
   builtinLibs.push('inspector');
   builtinLibs.sort();

--- a/lib/wasi.js
+++ b/lib/wasi.js
@@ -1,10 +1,12 @@
-// TODO(cjihrig): Put WASI behind a flag.
 'use strict';
 /* global WebAssembly */
 const { Array, ArrayPrototype, Object } = primordials;
 const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
+const { emitExperimentalWarning } = require('internal/util');
 const { WASI: _WASI } = internalBinding('wasi');
 const kSetMemory = Symbol('setMemory');
+
+emitExperimentalWarning('WASI');
 
 
 class WASI {

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -84,6 +84,9 @@ static void Initialize(Local<Object> target,
 
   READONLY_PROPERTY(target, "hasCachedBuiltins",
      v8::Boolean::New(isolate, native_module::has_code_cache));
+
+  if (per_process::cli_options->per_isolate->per_env->experimental_wasi)
+    READONLY_TRUE_PROPERTY(target, "experimentalWasi");
 }  // InitConfig
 
 }  // namespace node

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -349,6 +349,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::experimental_report,
             kAllowedInEnvironment);
 #endif  // NODE_REPORT
+  AddOption("--experimental-wasi",
+            "experimental WASI support",
+            &EnvironmentOptions::experimental_wasi,
+            kAllowedInEnvironment);
   AddOption("--expose-internals", "", &EnvironmentOptions::expose_internals);
   AddOption("--frozen-intrinsics",
             "experimental frozen intrinsics support",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -147,6 +147,7 @@ class EnvironmentOptions : public Options {
 #ifdef NODE_REPORT
   bool experimental_report = false;
 #endif  //  NODE_REPORT
+  bool experimental_wasi = false;
   std::string eval_string;
   bool print_eval = false;
   bool force_repl = false;

--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -81,13 +81,12 @@ using v8::Value;
 WASI::WASI(Environment* env,
            Local<Object> object,
            uvwasi_options_t* options) : BaseObject(env, object) {
-  /* uvwasi_errno_t err = */ uvwasi_init(&uvw_, options);
+  CHECK_EQ(uvwasi_init(&uvw_, options), UVWASI_ESUCCESS);
   memory_.Reset();
 }
 
 
 WASI::~WASI() {
-  /* TODO(cjihrig): Free memory. */
   uvwasi_destroy(&uvw_);
 }
 

--- a/test/wasi/test-wasi-binding.js
+++ b/test/wasi/test-wasi-binding.js
@@ -1,3 +1,4 @@
+// Flags: --experimental-wasi
 'use strict';
 
 const common = require('../common');

--- a/test/wasi/test-wasi.js
+++ b/test/wasi/test-wasi.js
@@ -1,11 +1,16 @@
 'use strict';
-require('../common');
+const common = require('../common');
 
 if (process.argv[2] === 'wasi-child') {
   const fixtures = require('../common/fixtures');
   const tmpdir = require('../../test/common/tmpdir');
   const fs = require('fs');
   const path = require('path');
+
+  common.expectWarning('ExperimentalWarning',
+                       'WASI is an experimental feature. This feature could ' +
+                       'change at any time');
+
   const { WASI } = require('wasi');
   tmpdir.refresh();
   const wasmDir = path.join(__dirname, 'wasm');
@@ -38,6 +43,7 @@ if (process.argv[2] === 'wasi-child') {
       opts.input = options.stdin;
 
     const child = cp.spawnSync(process.execPath, [
+      '--experimental-wasi',
       '--experimental-wasm-bigint',
       __filename,
       'wasi-child',


### PR DESCRIPTION
This commit puts the WASI implementation behind an `--experimental-wasi` CLI flag, and prints an experimental warning on first use of WASI. It also includes some misc cleanup.
