### PR TITLE
wasi: sync with latest uvwasi

### DIFF
--- a/deps/uvwasi/include/fd_table.h
+++ b/deps/uvwasi/include/fd_table.h
@@ -22,7 +22,7 @@ struct uvwasi_fd_wrap_t {
   uv_file fd;
   char path[PATH_MAX_BYTES];
   char real_path[PATH_MAX_BYTES];
-  uvwasi_filetype_t type; /* TODO(cjihrig): It probably isn't safe to cache. */
+  uvwasi_filetype_t type;
   uvwasi_rights_t rights_base;
   uvwasi_rights_t rights_inheriting;
   int preopen;

--- a/deps/uvwasi/include/uvwasi.h
+++ b/deps/uvwasi/include/uvwasi.h
@@ -9,6 +9,19 @@ extern "C" {
 #include "uv_mapping.h"
 #include "fd_table.h"
 
+#define UVWASI_VERSION_MAJOR 0
+#define UVWASI_VERSION_MINOR 0
+#define UVWASI_VERSION_PATCH 1
+#define UVWASI_VERSION_HEX ((UVWASI_VERSION_MAJOR << 16) | \
+                            (UVWASI_VERSION_MINOR <<  8) | \
+                            (UVWASI_VERSION_PATCH))
+#define UVWASI_STRINGIFY(v) UVWASI_STRINGIFY_HELPER(v)
+#define UVWASI_STRINGIFY_HELPER(v) #v
+#define UVWASI_VERSION_STRING UVWASI_STRINGIFY(UVWASI_VERSION_MAJOR) "." \
+                              UVWASI_STRINGIFY(UVWASI_VERSION_MINOR) "." \
+                              UVWASI_STRINGIFY(UVWASI_VERSION_PATCH)
+
+
 typedef struct uvwasi_s {
   struct uvwasi_fd_table_t fds;
   size_t argc;
@@ -51,7 +64,7 @@ uvwasi_errno_t uvwasi_clock_time_get(uvwasi_t* uvwasi,
                                      uvwasi_timestamp_t precision,
                                      uvwasi_timestamp_t* time);
 uvwasi_errno_t uvwasi_environ_get(uvwasi_t* uvwasi,
-                                  char** environ,
+                                  char** environment,
                                   char* environ_buf);
 uvwasi_errno_t uvwasi_environ_sizes_get(uvwasi_t* uvwasi,
                                         size_t* environ_count,

--- a/deps/uvwasi/src/fd_table.c
+++ b/deps/uvwasi/src/fd_table.c
@@ -356,7 +356,7 @@ uvwasi_errno_t uvwasi_fd_table_insert_fd(struct uvwasi_fd_table_t* table,
   r = uvwasi__fd_table_insert(table,
                               fd,
                               path,
-                              path, /* TODO(cjihrig): Fix this double path. */
+                              path,
                               type,
                               rights_base & max_base,
                               rights_inheriting & max_inheriting,


### PR DESCRIPTION
This sync includes several of the outstanding API calls (`poll_oneoff()` is the only one that really still needs to be implemented), misc cleanup, and a versioning mechanism.